### PR TITLE
Feature/payment

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -13,3 +13,12 @@ MONGODB_ENDPOINT=<docdb.amazonaws.com.endpoint>
 JWT_SECRET=secert
 
 LOG_FILE_DIR=logs
+
+# NewebPay
+NEWEBPAY_VERSION=1.5
+NEWEBPAY_MERCHANT_ID=MSxxxxxxxxx
+NEWEBPAY_HASH_KEY=secert
+NEWEBPAY_HASH_IV=secert
+NEWEBPAY_HOST=http://localhost:3000
+NEWEBPAY_RETURN_URL=http://localhost:3000/newebpay/return
+NEWEBPAY_NOTIFY_URL=http://localhost:3000/newebpay/notifiy

--- a/src/controllers/order.ts
+++ b/src/controllers/order.ts
@@ -34,6 +34,20 @@ const orderController = {
     const result = await orderService.deleteSeat({ order, ...req.body });
     res.json(Body.success(result));
   }),
+  payment: catchAsyncError(async (req, res) => {
+    const result = await orderService.payment(
+      req.userId!,
+      req.params.orderNo
+    );
+    res.json(Body.success(result));
+  }),
+  paymentNotify: catchAsyncError(async (req, res) => {
+    const result = await orderService.paymentNotify(req.body);
+    // TODO: parse result
+
+    // Respond to NewebPay
+    res.status(200).send('OK');
+  }),
 };
 
 export default orderController;

--- a/src/controllers/order.ts
+++ b/src/controllers/order.ts
@@ -42,11 +42,14 @@ const orderController = {
     res.json(Body.success(result));
   }),
   paymentNotify: catchAsyncError(async (req, res) => {
-    const result = await orderService.paymentNotify(req.body);
-    // TODO: parse result
+    const result = await orderService.paymentNotify(req.body.TradeInfo);
 
     // Respond to NewebPay
-    res.status(200).send('OK');
+    if (result) {
+      res.status(200).send('OK');
+    } else {
+      res.status(500).send('Failed');
+    }
   }),
 };
 

--- a/src/enums/orderStatus.ts
+++ b/src/enums/orderStatus.ts
@@ -2,4 +2,5 @@ export enum OrderStatus {
   UNPAID,
   PAID,
   CANCELLED,
+  FAIL
 }

--- a/src/routes/order.ts
+++ b/src/routes/order.ts
@@ -67,6 +67,11 @@ orderRouter.get(
 
 orderRouter.post(
   '/payment_notify',
+  validateRequestBody(
+    z.object({
+      TradeInfo: z.string(),
+    }),
+  ),
   orderController.paymentNotify,
 );
 

--- a/src/routes/order.ts
+++ b/src/routes/order.ts
@@ -58,4 +58,16 @@ orderRouter.delete(
   orderController.deleteSeat,
 );
 
+orderRouter.get(
+  '/:orderNo/payment',
+  isAuth,
+  validateRequestParams(z.object({ orderNo: z.string() })),
+  orderController.payment,
+);
+
+orderRouter.post(
+  '/payment_notify',
+  orderController.paymentNotify,
+);
+
 export default orderRouter;

--- a/src/services/order/index.ts
+++ b/src/services/order/index.ts
@@ -3,6 +3,8 @@ import addSeats from './addSeats';
 import createOrderNo from './createOrderNo';
 import deleteSeat from './deleteSeat';
 import getOrderInfo from './getOrderInfo';
+import payment from './payment';
+import paymentNotify from './paymentNotify';
 
 const orderService = {
   getOrderInfo,
@@ -10,6 +12,8 @@ const orderService = {
   createOrderNo,
   addSeats,
   deleteSeat,
+  payment,
+  paymentNotify,
 };
 
 export default orderService;

--- a/src/services/order/payment.ts
+++ b/src/services/order/payment.ts
@@ -8,7 +8,7 @@ import { StatusCode } from '@/enums/statusCode';
 import TicketModel from '@/models/ticket';
 
 const RespondType = 'JSON';
-const { NEWEBPAY_VERSION, NEWEBPAY_MERCHANT_ID, NEWEBPAY_HASH_KEY, NEWEBPAY_HASH_IV } = process.env;
+const { NEWEBPAY_VERSION, NEWEBPAY_MERCHANT_ID, NEWEBPAY_HASH_KEY, NEWEBPAY_HASH_IV, NEWEBPAY_RETURN_URL, NEWEBPAY_NOTIFY_URL } = process.env;
 
 interface NewebPayPaymentRequest {
   MerchantOrderNo: string;
@@ -26,7 +26,7 @@ const formatDesc = (name: string, quantity: number, start_at: Date) => {
 };
 
 const genDataChain = (paymentData: NewebPayPaymentRequest) => {
-  return `MerchantID=${NEWEBPAY_MERCHANT_ID}&RespondType=${RespondType}&TimeStamp=${paymentData.TimeStamp}&Version=${NEWEBPAY_VERSION}&MerchantOrderNo=${paymentData.MerchantOrderNo}&Amt=${paymentData.Amt}&ItemDesc=${encodeURIComponent(paymentData.ItemDesc).replace(/%20/g, '+')}&Email=${encodeURIComponent(paymentData.Email)}`;//&ReturnURL=${NEWEBPAY_RETURN_URL}&NotifyURL=${NEWEBPAY_NOTIFY_URL}`;
+  return `MerchantID=${NEWEBPAY_MERCHANT_ID}&RespondType=${RespondType}&TimeStamp=${paymentData.TimeStamp}&Version=${NEWEBPAY_VERSION}&MerchantOrderNo=${paymentData.MerchantOrderNo}&Amt=${paymentData.Amt}&ItemDesc=${encodeURIComponent(paymentData.ItemDesc).replace(/%20/g, '+')}&Email=${encodeURIComponent(paymentData.Email)}&ReturnURL=${NEWEBPAY_RETURN_URL}&NotifyURL=${NEWEBPAY_NOTIFY_URL}`;
 }
 
 const createAesEncrypt = (tradeInfo: NewebPayPaymentRequest) => {

--- a/src/services/order/payment.ts
+++ b/src/services/order/payment.ts
@@ -7,7 +7,7 @@ import { appError } from '../appError';
 import { StatusCode } from '@/enums/statusCode';
 
 const RespondType = 'JSON';
-const { NEWEBPAY_VERSION, NEWEBPAY_MERCHANT_ID, NEWEBPAY_HASH_KEY, NEWEBPAY_HASH_IV, NEWEBPAY_HOST, NEWEBPAY_RETURN_URL, NEWEBPAY_NOTIFY_URL } = process.env;
+const { NEWEBPAY_VERSION, NEWEBPAY_MERCHANT_ID, NEWEBPAY_HASH_KEY, NEWEBPAY_HASH_IV } = process.env;
 
 interface NewebPayPaymentRequest {
   MerchantOrderNo: string;
@@ -32,8 +32,8 @@ const createAesEncrypt = (tradeInfo: NewebPayPaymentRequest) => {
   if (!NEWEBPAY_HASH_KEY || !NEWEBPAY_HASH_IV) {
     throw appError(500, StatusCode.SERVER_ERROR, 'NEWEBPAY_HASH_KEY or NEWEBPAY_HASH_IV not found')
   }
-  const cipher = crypto.createCipheriv('aes-256-cbc', NEWEBPAY_HASH_KEY, NEWEBPAY_HASH_IV);
-  const encrypted = cipher.update(genDataChain(tradeInfo), 'utf8', 'hex') + cipher.final('hex');
+  const encrypt = crypto.createCipheriv('aes-256-cbc', NEWEBPAY_HASH_KEY, NEWEBPAY_HASH_IV);
+  const encrypted = encrypt.update(genDataChain(tradeInfo), 'utf8', 'hex') + encrypt.final('hex');
   return encrypted;
 }
 

--- a/src/services/order/payment.ts
+++ b/src/services/order/payment.ts
@@ -1,0 +1,79 @@
+import crypto from 'crypto';
+import { NotFoundException } from "@/exceptions/NotFoundException";
+import { Activity } from "@/models/activity";
+import OrderModel from "@/models/order";
+import { User } from "@/models/user";
+import { appError } from '../appError';
+import { StatusCode } from '@/enums/statusCode';
+
+const RespondType = 'JSON';
+const { NEWEBPAY_VERSION, NEWEBPAY_MERCHANT_ID, NEWEBPAY_HASH_KEY, NEWEBPAY_HASH_IV, NEWEBPAY_HOST, NEWEBPAY_RETURN_URL, NEWEBPAY_NOTIFY_URL } = process.env;
+
+interface NewebPayPaymentRequest {
+  MerchantOrderNo: string;
+  RespondType: string;
+  TimeStamp: number;
+  Email: string;
+  Amt: number;
+  ItemDesc: string;
+}
+
+const formatDesc = (name: string, quantity: number, start_at: Date) => {
+  const formattedName = name.length > 35 ? name.slice(0, 32) + '...' : name;
+  const formattedDate = new Date(start_at).toISOString().slice(0, 10);
+  return `${formattedName} ${quantity} 張 [${formattedDate}]`;
+};
+
+function genDataChain(paymentData: NewebPayPaymentRequest) {
+  return `MerchantID=${NEWEBPAY_MERCHANT_ID}&RespondType=${RespondType}&TimeStamp=${paymentData.TimeStamp}&Version=${NEWEBPAY_VERSION}&MerchantOrderNo=${paymentData.MerchantOrderNo}&Amt=${paymentData.Amt}&ItemDesc=${encodeURIComponent(paymentData.ItemDesc).replace(/%20/g, '+')}&Email=${encodeURIComponent(paymentData.Email)}`;//&ReturnURL=${NEWEBPAY_RETURN_URL}&NotifyURL=${NEWEBPAY_NOTIFY_URL}`;
+}
+
+function createAesEncrypt(tradeInfo: NewebPayPaymentRequest) {
+  if (!NEWEBPAY_HASH_KEY || !NEWEBPAY_HASH_IV) {
+    throw appError(500, StatusCode.SERVER_ERROR, 'NEWEBPAY_HASH_KEY or NEWEBPAY_HASH_IV not found')
+  }
+  const cipher = crypto.createCipheriv('aes-256-cbc', NEWEBPAY_HASH_KEY, NEWEBPAY_HASH_IV);
+  const encrypted = cipher.update(genDataChain(tradeInfo), 'utf8', 'hex') + cipher.final('hex');
+  return encrypted;
+}
+
+function createShaEncrypt(aesEncrypt: string) {
+  if (!NEWEBPAY_HASH_KEY || !NEWEBPAY_HASH_IV) {
+    throw appError(500, StatusCode.SERVER_ERROR, 'NEWEBPAY_HASH_KEY or NEWEBPAY_HASH_IV not found')
+  }
+  const sha = crypto.createHash('sha256');
+  const plainText = `HashKey=${NEWEBPAY_HASH_KEY}&${aesEncrypt}&HashIV=${NEWEBPAY_HASH_IV}`;
+  return sha.update(plainText).digest('hex').toUpperCase();
+}
+
+const payment = async (userId: string, orderNo: string) => {
+  const order = await OrderModel.findOne({
+    order_no: orderNo,
+    user_id: userId,
+  })
+    .select('order_no price user_id activity_id')
+    .populate<{ user_id: User }>('user_id', 'email')
+    .populate<{ activity_id: Activity }>('activity_id', 'name seat_total start_at');
+
+  if (!order) throw new NotFoundException();
+
+  const paymentData = {
+    'MerchantOrderNo': order.order_no,
+    'RespondType': RespondType,
+    'TimeStamp': Math.floor(Date.now() / 1000),
+    'Email': order.user_id.email,
+    'Amt': order.price,
+    'ItemDesc': formatDesc(order.activity_id.name, order.activity_id.seat_total, order.activity_id.start_at),
+  };
+
+  const aesEncrypt = createAesEncrypt(paymentData);
+  const shaEncrypt = createShaEncrypt(aesEncrypt);
+
+  return {
+    paymentData,
+    aesEncrypt,
+    shaEncrypt,
+  };
+};
+
+export default payment;

--- a/src/services/order/payment.ts
+++ b/src/services/order/payment.ts
@@ -24,11 +24,11 @@ const formatDesc = (name: string, quantity: number, start_at: Date) => {
   return `${formattedName} ${quantity} 張 [${formattedDate}]`;
 };
 
-function genDataChain(paymentData: NewebPayPaymentRequest) {
+const genDataChain = (paymentData: NewebPayPaymentRequest) => {
   return `MerchantID=${NEWEBPAY_MERCHANT_ID}&RespondType=${RespondType}&TimeStamp=${paymentData.TimeStamp}&Version=${NEWEBPAY_VERSION}&MerchantOrderNo=${paymentData.MerchantOrderNo}&Amt=${paymentData.Amt}&ItemDesc=${encodeURIComponent(paymentData.ItemDesc).replace(/%20/g, '+')}&Email=${encodeURIComponent(paymentData.Email)}`;//&ReturnURL=${NEWEBPAY_RETURN_URL}&NotifyURL=${NEWEBPAY_NOTIFY_URL}`;
 }
 
-function createAesEncrypt(tradeInfo: NewebPayPaymentRequest) {
+const createAesEncrypt = (tradeInfo: NewebPayPaymentRequest) => {
   if (!NEWEBPAY_HASH_KEY || !NEWEBPAY_HASH_IV) {
     throw appError(500, StatusCode.SERVER_ERROR, 'NEWEBPAY_HASH_KEY or NEWEBPAY_HASH_IV not found')
   }
@@ -37,7 +37,7 @@ function createAesEncrypt(tradeInfo: NewebPayPaymentRequest) {
   return encrypted;
 }
 
-function createShaEncrypt(aesEncrypt: string) {
+const createShaEncrypt = (aesEncrypt: string) => {
   if (!NEWEBPAY_HASH_KEY || !NEWEBPAY_HASH_IV) {
     throw appError(500, StatusCode.SERVER_ERROR, 'NEWEBPAY_HASH_KEY or NEWEBPAY_HASH_IV not found')
   }

--- a/src/services/order/paymentNotify.ts
+++ b/src/services/order/paymentNotify.ts
@@ -31,7 +31,7 @@ const paymentNotify = async (tradeInfo: string) => {
     { $set: { status: status } },
   );
 
-  console.log(status);
+  console.log(info);
 
   // TODO: Save the payment info to neweb_paymethods
   // info.Result.PayTime

--- a/src/services/order/paymentNotify.ts
+++ b/src/services/order/paymentNotify.ts
@@ -31,6 +31,8 @@ const paymentNotify = async (tradeInfo: string) => {
     { $set: { status: status } },
   );
 
+  console.log(info);
+
   // TODO: Save the payment info to neweb_paymethods
   // info.Result.PayTime
   // info.Result.PaymentType

--- a/src/services/order/paymentNotify.ts
+++ b/src/services/order/paymentNotify.ts
@@ -23,7 +23,7 @@ const paymentNotify = async (tradeInfo: string) => {
   const info = createAesDecrypt(tradeInfo);
 
   // Ensure info.Result.Status is not undefined
-  const status = info?.Result?.Status === 'SUCCESS' ? OrderStatus.PAID : OrderStatus.FAIL;
+  const status = info?.Status === 'SUCCESS' ? OrderStatus.PAID : OrderStatus.FAIL;
 
   // Find and update order status
   const order = await OrderModel.updateOne(

--- a/src/services/order/paymentNotify.ts
+++ b/src/services/order/paymentNotify.ts
@@ -23,7 +23,7 @@ const paymentNotify = async (tradeInfo: string) => {
   const info = createAesDecrypt(tradeInfo);
 
   // Ensure info.Result.Status is not undefined
-  const status = info?.Result?.Status ? OrderStatus[info.Result.Status] : OrderStatus["FAIL"];
+  const status = info?.Result?.Status === 'SUCCESS' ? OrderStatus.PAID : OrderStatus.FAIL;
 
   // Find and update order status
   const order = await OrderModel.updateOne(
@@ -31,7 +31,7 @@ const paymentNotify = async (tradeInfo: string) => {
     { $set: { status: status } },
   );
 
-  // TODO: Save the payment info
+  // TODO: Save the payment info to neweb_paymethods
   // info.Result.PayTime
   // info.Result.PaymentType
   // info.Result.IP

--- a/src/services/order/paymentNotify.ts
+++ b/src/services/order/paymentNotify.ts
@@ -1,9 +1,42 @@
+import crypto from 'crypto';
+import { StatusCode } from "@/enums/statusCode";
+import { appError } from "../appError";
+import OrderModel from '@/models/order';
+import { OrderStatus } from '@/enums/orderStatus';
 
+const { NEWEBPAY_HASH_KEY, NEWEBPAY_HASH_IV } = process.env;
 
-const paymentNotify = async (body: any) => {
-  // TODO: deencrypt body
+const createAesDecrypt = (tradeInfo: string) => {
+  if (!NEWEBPAY_HASH_KEY || !NEWEBPAY_HASH_IV) {
+    throw appError(500, StatusCode.SERVER_ERROR, 'NEWEBPAY_HASH_KEY or NEWEBPAY_HASH_IV not found')
+  }
+  const decrypt = crypto.createDecipheriv('aes-256-cbc', NEWEBPAY_HASH_KEY, NEWEBPAY_HASH_IV);
+  decrypt.setAutoPadding(false);
+  const text = decrypt.update(tradeInfo, 'hex', 'utf8');
+  const plainText = text + decrypt.final('utf8');
+  // const result = plainText.replace(/\x00|[\x01-\x20]+/g, '');
+  const result = plainText.replace(/[\p{C}]+/gu, '');
+  return JSON.parse(result);
+}
 
-  return null;
+const paymentNotify = async (tradeInfo: string) => {
+  const info = createAesDecrypt(tradeInfo);
+
+  // Ensure info.Result.Status is not undefined
+  const status = info?.Result?.Status ? OrderStatus[info.Result.Status] : OrderStatus["FAIL"];
+
+  // Find and update order status
+  const order = await OrderModel.updateOne(
+    { order_no: info.Result.MerchantOrderNo },
+    { $set: { status: status } },
+  );
+
+  // TODO: Save the payment info
+  // info.Result.PayTime
+  // info.Result.PaymentType
+  // info.Result.IP
+
+  return true;
 };
 
 export default paymentNotify;

--- a/src/services/order/paymentNotify.ts
+++ b/src/services/order/paymentNotify.ts
@@ -1,0 +1,9 @@
+
+
+const paymentNotify = async (body: any) => {
+  // TODO: deencrypt body
+
+  return null;
+};
+
+export default paymentNotify;

--- a/src/services/order/paymentNotify.ts
+++ b/src/services/order/paymentNotify.ts
@@ -31,8 +31,6 @@ const paymentNotify = async (tradeInfo: string) => {
     { $set: { status: status } },
   );
 
-  console.log(info);
-
   // TODO: Save the payment info to neweb_paymethods
   // info.Result.PayTime
   // info.Result.PaymentType

--- a/src/services/order/paymentNotify.ts
+++ b/src/services/order/paymentNotify.ts
@@ -31,7 +31,7 @@ const paymentNotify = async (tradeInfo: string) => {
     { $set: { status: status } },
   );
 
-  console.log(info);
+  console.log(status);
 
   // TODO: Save the payment info to neweb_paymethods
   // info.Result.PayTime


### PR DESCRIPTION
藍新支付，完成
- 付款：回給前端藍新加密資料
- 藍新notify：更新資料庫中訂單狀態
- 使用簡易前端測試，頁面會跳轉，notify也有成功觸發

未完成
- 更換notify（目前設定為此pr的render網址下 `/orders/payment_notify`）、return url
- 儲存藍新交易資訊至 `neweb_paymethods`
- 藍新交易失敗代碼處理