### PR TITLE
feat: Add qrcode verify link generator

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "ramda": "^0.29.0",
     "swagger-jsdoc": "^6.2.8",
     "swagger-ui-express": "^4.6.2",
+    "uuid": "^9.0.0",
     "winston": "^3.8.2",
     "winston-daily-rotate-file": "^4.7.1",
     "zod": "^3.21.4"
@@ -55,6 +56,7 @@
     "@types/supertest": "^2.0.12",
     "@types/swagger-jsdoc": "^6.0.1",
     "@types/swagger-ui-express": "^4.1.3",
+    "@types/uuid": "^9.0.1",
     "@typescript-eslint/eslint-plugin": "^5.59.0",
     "@typescript-eslint/parser": "^5.59.0",
     "concurrently": "^8.0.1",

--- a/src/models/activity.ts
+++ b/src/models/activity.ts
@@ -1,6 +1,6 @@
 import { Region } from '@/enums/region';
 import toValidate from '@/utils/toValidate';
-import { InferSchemaType, ObjectId, Schema, Types, model } from 'mongoose';
+import { InferSchemaType, Schema, Types, model } from 'mongoose';
 import { z } from 'zod';
 
 const subAreaSchema = new Schema({

--- a/src/services/activity/qrcodeVerifyLink.ts
+++ b/src/services/activity/qrcodeVerifyLink.ts
@@ -1,0 +1,21 @@
+import { Types } from 'mongoose';
+import { v4 as uuidv4 } from 'uuid';
+import ActivityModel from '@/models/activity';
+import { NotFoundException } from '@/exceptions/NotFoundException';
+
+const generateVerifyLink = async (eventId: string | Types.ObjectId) => {
+  const activity = await ActivityModel.findOne({})
+    .where('events._id')
+    .equals(eventId);
+  const event = activity?.events.id(eventId);
+  if (!activity || !event) throw new NotFoundException();
+
+  const linkId = uuidv4();
+  event.qrcode_verify_link = linkId;
+
+  await activity.save();
+
+  return event.qrcode_verify_link;
+};
+
+export default generateVerifyLink;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2526,6 +2526,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/uuid@npm:^9.0.1":
+  version: 9.0.1
+  resolution: "@types/uuid@npm:9.0.1"
+  checksum: c472b8a77cbeded4bc529220b8611afa39bd64677f507838f8083d8aac8033b1f88cb9ddaa2f8589e0dcd2317291d0f6e1379f82d5ceebd6f74f3b4825288e00
+  languageName: node
+  linkType: hard
+
 "@types/webidl-conversions@npm:*":
   version: 7.0.0
   resolution: "@types/webidl-conversions@npm:7.0.0"
@@ -9314,6 +9321,7 @@ __metadata:
     "@types/supertest": ^2.0.12
     "@types/swagger-jsdoc": ^6.0.1
     "@types/swagger-ui-express": ^4.1.3
+    "@types/uuid": ^9.0.1
     "@typescript-eslint/eslint-plugin": ^5.59.0
     "@typescript-eslint/parser": ^5.59.0
     bcrypt: ^5.1.0
@@ -9348,6 +9356,7 @@ __metadata:
     ts-node: ^10.9.1
     tsconfig-paths: ^4.2.0
     typescript: ^5.0.4
+    uuid: ^9.0.0
     winston: ^3.8.2
     winston-daily-rotate-file: ^4.7.1
     zod: ^3.21.4
@@ -9762,6 +9771,15 @@ __metadata:
   bin:
     uuid: dist/bin/uuid
   checksum: 5575a8a75c13120e2f10e6ddc801b2c7ed7d8f3c8ac22c7ed0c7b2ba6383ec0abda88c905085d630e251719e0777045ae3236f04c812184b7c765f63a70e58df
+  languageName: node
+  linkType: hard
+
+"uuid@npm:^9.0.0":
+  version: 9.0.0
+  resolution: "uuid@npm:9.0.0"
+  bin:
+    uuid: dist/bin/uuid
+  checksum: 8dd2c83c43ddc7e1c71e36b60aea40030a6505139af6bee0f382ebcd1a56f6cd3028f7f06ffb07f8cf6ced320b76aea275284b224b002b289f89fe89c389b028
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
產生qrcode掃描驗證頁面的 id

前端可自訂驗證頁面 url (例如 /event/verify/:id)，但須要在驗票 api 帶入此 id 作為驗票人員的識別。