### PR TITLE
chore: Add redis env variable to .env.test

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -8,6 +8,9 @@ MONGODB_DATABASE=test
 MONGODB_CONNECT_STRING=mongodb+srv://<user>:<password>@xxxxxxxxxxx/<database>?retryWrites=true&w=majority
 MONGODB_ENDPOINT=xxxxxxxxxxxxxxxx.docdb.amazonaws.com
 
+# redis
+REDIS_CONNECT_STRING=redis://127.0.0.1:6379/0
+
 JWT_SECRET=secret
 LOG_FILE_DIR=logs
 


### PR DESCRIPTION
新增 `REDIS_CONNECT_STRING` 至 `.env.test`