### PR TITLE
ci: Remove GitHub Actions test temporarily

### DIFF
--- a/.github/workflows/aws.yml
+++ b/.github/workflows/aws.yml
@@ -6,39 +6,7 @@ on:
       - main
 
 jobs:
-  test:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout Repo
-        uses: actions/checkout@v3
-
-      - name: Use Node.js
-        uses: actions/setup-node@v3
-
-      - name: Install Dependencies
-        run: yarn install
-
-      - name: Copy .env.test to .env
-        run: cp .env.test .env
-
-      - name: Run tests
-        run: yarn test
-
-      - name: Rollback
-        if: ${{ failure() && github.event_name == 'push' }}
-        run: |
-          git checkout ${{ github.sha }}^1
-          git push --force
-
-          # Post a comment on the pull request
-          curl -X POST \
-            -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
-            -H "Content-Type: application/json" \
-            -d '{"body": "The CI job has failed. The last commit has been rolled back."}' \
-            "https://api.github.com/repos/${GITHUB_REPOSITORY}/issues/${{ github.event.pull_request.number }}/comments"
-
   deploy:
-    needs: test
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repo
@@ -68,16 +36,3 @@ jobs:
           region: ${{ secrets.AWS_REGION }}
           deployment_package: deploy.zip
           use_existing_version_if_available: true
-
-      - name: Rollback
-        if: ${{ failure() && github.event_name == 'push' }}
-        run: |
-          git checkout ${{ github.sha }}^1
-          git push --force
-
-          # Post a comment on the pull request
-          curl -X POST \
-            -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
-            -H "Content-Type: application/json" \
-            -d '{"body": "The CI job has failed. The last commit has been rolled back."}' \
-            "https://api.github.com/repos/${GITHUB_REPOSITORY}/issues/${{ github.event.pull_request.number }}/comments"

--- a/.github/workflows/render.yml
+++ b/.github/workflows/render.yml
@@ -7,42 +7,7 @@ on:
       - develop
 
 jobs:
-  test:
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        node-version: [16.x]
-    steps:
-      - name: Checkout Repo
-        uses: actions/checkout@v3
-
-      - name: Use Node.js
-        uses: actions/setup-node@v3
-
-      - name: Install Dependencies
-        run: yarn install
-
-      - name: Copy .env.test to .env
-        run: cp .env.test .env
-
-      - name: Run tests
-        run: yarn test
-
-      - name: Rollback
-        if: ${{ failure() && github.event_name == 'push' }}
-        run: |
-          git checkout ${{ github.sha }}^1
-          git push --force
-
-          # Post a comment on the pull request
-          curl -X POST \
-            -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
-            -H "Content-Type: application/json" \
-            -d '{"body": "The CI job has failed. The last commit has been rolled back."}' \
-            "https://api.github.com/repos/${GITHUB_REPOSITORY}/issues/${{ github.event.pull_request.number }}/comments"
-
   deploy:
-    needs: test
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -65,16 +30,3 @@ jobs:
         with:
           service-id: ${{ secrets.SERVICE_ID_DEVELOP }} # Can be found as part of the Deploy Hook
           api-key: ${{ secrets.RENDER_API_KEY }} # Create your API key in Render Dashboard > Account Settings
-
-      - name: Rollback
-        if: ${{ failure() && github.event_name == 'push' }}
-        run: |
-          git checkout ${{ github.sha }}^1
-          git push --force
-
-          # Post a comment on the pull request
-          curl -X POST \
-            -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
-            -H "Content-Type: application/json" \
-            -d '{"body": "The CI job has failed. The last commit has been rolled back."}' \
-            "https://api.github.com/repos/${GITHUB_REPOSITORY}/issues/${{ github.event.pull_request.number }}/comments"


### PR DESCRIPTION
暫時移除 GitHub Actions 的 test ，因為在測試DB時候卡住，Peter 建議使用 mock 測試 DB 或 [MongoDB In-Memory Server](https://github.com/nodkz/mongodb-memory-server)。規劃之後補。